### PR TITLE
Улучшения сборки EDT

### DIFF
--- a/src/edt/2023.Dockerfile
+++ b/src/edt/2023.Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update \
     libgtk-3-0 \
     locales \
     ca-certificates \
+    openjfx \
   && apt-get clean \
   && rm -rf  \
     /var/lib/apt/lists/* \

--- a/src/edt/2023.Dockerfile
+++ b/src/edt/2023.Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
     locales \
     ca-certificates \
     openjfx \
+    libopenjfx-java \
   && apt-get clean \
   && rm -rf  \
     /var/lib/apt/lists/* \
@@ -60,6 +61,7 @@ RUN chmod +x ./1ce-installer-cli \
   && ln -sfn "$(dirname "$RING_PATH")" /opt/1C/1CE/components/1c-enterprise-ring \
   && ln -sfn "$(dirname "$EDT_PATH")" /opt/1C/1CE/components/1cedt \
   && sed -i -e 's/4096m/12288m/g' "$(dirname "$EDT_PATH")"/1cedt.ini \
+  && sed -i '/^-Xmx/a --add-modules=javafx.controls,javafx.fxml,javafx.web\n--module-path=/usr/share/openjfx/lib' "$(dirname "$EDT_PATH")"/1cedt.ini \
   && "$(dirname "$EDT_PATH")"/1cedt -clean -purgeHistory -application org.eclipse.equinox.p2.director -noSplash -repository https://marmyshev.gitlab.io/edt-editing/update -installIU org.mard.dt.editing.feature.feature.group/${EDT_DISABLE_EDITING_VERSION} \
   && rm -f "$(dirname "$EDT_PATH")"/configuration/*.log \
   && rm -rf "$(dirname "$EDT_PATH")"/configuration/org.eclipse.core.runtime \

--- a/src/edt/2023.Dockerfile
+++ b/src/edt/2023.Dockerfile
@@ -49,26 +49,26 @@ COPY --from=downloader /tmp/${downloads} /tmp/${downloads}
 
 WORKDIR /tmp/${downloads}
 
-RUN chmod +x ./1ce-installer-cli \
-  && ./1ce-installer-cli install all --ignore-hardware-checks --ignore-signature-warnings && \
-  RING_PATH=$(find /opt/1C/1CE -type f -name ring -print -quit) && \
-  EDT_PATH=$(find /opt/1C/1CE -type f -name 1cedt -print -quit) && \
-  [ -n "$RING_PATH" ] && ln -s "$(dirname "$RING_PATH")" /opt/1C/1CE/components/1c-enterprise-ring && \
-  [ -n "$EDT_PATH" ] && ln -s "$(dirname "$EDT_PATH")" /opt/1C/1CE/components/1cedt && \
-  rm -rf /tmp/*
-
-# Install Disable Editing Plugin and cleanup
 ARG EDT_DISABLE_EDITING_VERSION=0.5.0.20240203-0530
-RUN /opt/1C/1CE/components/1cedt/1cedt -clean -purgeHistory -application org.eclipse.equinox.p2.director -noSplash -repository https://marmyshev.gitlab.io/edt-editing/update -installIU org.mard.dt.editing.feature.feature.group/${EDT_DISABLE_EDITING_VERSION} \
-  && rm -f /opt/1C/1CE/components/1cedt/configuration/*.log \
-  && rm -rf /opt/1C/1CE/components/1cedt/configuration/org.eclipse.core.runtime \
-  && rm -rf /opt/1C/1CE/components/1cedt/configuration/org.eclipse.osgi \
-  && rm -rf /opt/1C/1CE/components/1cedt/plugin-development \
-  && rm -f /opt/1C/1CE/components/1cedt/plugins/com._1c.g5.v8.dt.platform.doc_*.jar \
-  && rm -f /opt/1C/1CE/components/1cedt/plugins/com._1c.g5.v8.dt.platform.doc_v8_*.jar \
-  && rm -f /opt/1C/1CE/components/1cedt/plugins/com._1c.g5.v8.dt.product.doc_*.jar \
-  && rm -f /opt/1C/1CE/components/1cedt/plugins/org.eclipse.egit.doc_*.jar \
-  && rm -f /opt/1C/1CE/components/1cedt/plugins/org.eclipse.platform.doc_*.jar \
+RUN chmod +x ./1ce-installer-cli \
+  && ./1ce-installer-cli install all --ignore-hardware-checks --ignore-signature-warnings \
+  && RING_PATH="$(find /opt/1C/1CE -type f -name ring -print -quit)" \
+  && EDT_PATH="$(find /opt/1C/1CE -type f -name 1cedt -print -quit)" \
+  && [ -n "$RING_PATH" ] \
+  && [ -n "$EDT_PATH" ] \
+  && ln -sfn "$(dirname "$RING_PATH")" /opt/1C/1CE/components/1c-enterprise-ring \
+  && ln -sfn "$(dirname "$EDT_PATH")" /opt/1C/1CE/components/1cedt \
+  && sed -i -e 's/4096m/12288m/g' "$(dirname "$EDT_PATH")"/1cedt.ini \
+  && "$(dirname "$EDT_PATH")"/1cedt -clean -purgeHistory -application org.eclipse.equinox.p2.director -noSplash -repository https://marmyshev.gitlab.io/edt-editing/update -installIU org.mard.dt.editing.feature.feature.group/${EDT_DISABLE_EDITING_VERSION} \
+  && rm -f "$(dirname "$EDT_PATH")"/configuration/*.log \
+  && rm -rf "$(dirname "$EDT_PATH")"/configuration/org.eclipse.core.runtime \
+  && rm -rf "$(dirname "$EDT_PATH")"/configuration/org.eclipse.osgi \
+  && rm -rf "$(dirname "$EDT_PATH")"/plugin-development \
+  && rm -f "$(dirname "$EDT_PATH")"/plugins/com._1c.g5.v8.dt.platform.doc_*.jar \
+  && rm -f "$(dirname "$EDT_PATH")"/plugins/com._1c.g5.v8.dt.platform.doc_v8_*.jar \
+  && rm -f "$(dirname "$EDT_PATH")"/plugins/com._1c.g5.v8.dt.product.doc_*.jar \
+  && rm -f "$(dirname "$EDT_PATH")"/plugins/org.eclipse.egit.doc_*.jar \
+  && rm -f "$(dirname "$EDT_PATH")"/plugins/org.eclipse.platform.doc_*.jar \
   && rm -rf /tmp/*
 
 FROM base

--- a/src/edt/2023.Dockerfile
+++ b/src/edt/2023.Dockerfile
@@ -28,6 +28,8 @@ RUN apt-get update \
     libgtk-3-0 \
     locales \
     ca-certificates \
+  && (DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y libwebkit2gtk-4.0-37 \
+      || DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y libwebkit2gtk-4.1-0) \
   && apt-get clean \
   && rm -rf  \
     /var/lib/apt/lists/* \

--- a/src/edt/2023.Dockerfile
+++ b/src/edt/2023.Dockerfile
@@ -61,7 +61,7 @@ RUN chmod +x ./1ce-installer-cli \
   && ln -sfn "$(dirname "$RING_PATH")" /opt/1C/1CE/components/1c-enterprise-ring \
   && ln -sfn "$(dirname "$EDT_PATH")" /opt/1C/1CE/components/1cedt \
   && sed -i -e 's/4096m/12288m/g' "$(dirname "$EDT_PATH")"/1cedt.ini \
-  && "$(dirname "$EDT_PATH")"/1cedt -clean -purgeHistory -application org.eclipse.equinox.p2.director -noSplash -repository https://marmyshev.gitlab.io/edt-editing/update -installIU org.mard.dt.editing.feature.feature.group/${EDT_DISABLE_EDITING_VERSION} \
+  && "$(dirname "$EDT_PATH")"/1cedt -clean -purgeHistory -application org.eclipse.equinox.p2.director -noSplash -repository https://marmyshev.gitlab.io/edt-editing/update -installIU org.mard.dt.editing.feature.feature.group/${EDT_DISABLE_EDITING_VERSION} -vmargs -Dorg.eclipse.swt.browser.DefaultType=webkit \
   && rm -f "$(dirname "$EDT_PATH")"/configuration/*.log \
   && rm -rf "$(dirname "$EDT_PATH")"/configuration/org.eclipse.core.runtime \
   && rm -rf "$(dirname "$EDT_PATH")"/configuration/org.eclipse.osgi \

--- a/src/edt/2023.Dockerfile
+++ b/src/edt/2023.Dockerfile
@@ -28,8 +28,6 @@ RUN apt-get update \
     libgtk-3-0 \
     locales \
     ca-certificates \
-  && (DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y libwebkit2gtk-4.0-37 \
-      || DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y libwebkit2gtk-4.1-0) \
   && apt-get clean \
   && rm -rf  \
     /var/lib/apt/lists/* \

--- a/src/edt/2023.Dockerfile
+++ b/src/edt/2023.Dockerfile
@@ -61,7 +61,7 @@ RUN chmod +x ./1ce-installer-cli \
   && ln -sfn "$(dirname "$RING_PATH")" /opt/1C/1CE/components/1c-enterprise-ring \
   && ln -sfn "$(dirname "$EDT_PATH")" /opt/1C/1CE/components/1cedt \
   && sed -i -e 's/4096m/12288m/g' "$(dirname "$EDT_PATH")"/1cedt.ini \
-  && "$(dirname "$EDT_PATH")"/1cedt -clean -purgeHistory -application org.eclipse.equinox.p2.director -noSplash -repository https://marmyshev.gitlab.io/edt-editing/update -installIU org.mard.dt.editing.feature.feature.group/${EDT_DISABLE_EDITING_VERSION} -vmargs -Dorg.eclipse.swt.browser.DefaultType=webkit \
+  && "$(dirname "$EDT_PATH")"/1cedt -clean -purgeHistory -application org.eclipse.equinox.p2.director -noSplash -repository https://marmyshev.gitlab.io/edt-editing/update -installIU org.mard.dt.editing.feature.feature.group/${EDT_DISABLE_EDITING_VERSION} \
   && rm -f "$(dirname "$EDT_PATH")"/configuration/*.log \
   && rm -rf "$(dirname "$EDT_PATH")"/configuration/org.eclipse.core.runtime \
   && rm -rf "$(dirname "$EDT_PATH")"/configuration/org.eclipse.osgi \

--- a/src/edt/2024.Dockerfile
+++ b/src/edt/2024.Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update \
     libgtk-3-0 \
     locales \
     ca-certificates \
+    openjfx \
   && apt-get clean \
   && rm -rf  \
     /var/lib/apt/lists/* \

--- a/src/edt/2024.Dockerfile
+++ b/src/edt/2024.Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
     locales \
     ca-certificates \
     openjfx \
+    libopenjfx-java \
   && apt-get clean \
   && rm -rf  \
     /var/lib/apt/lists/* \
@@ -60,6 +61,7 @@ RUN chmod +x ./1ce-installer-cli \
   && ln -sfn "$(dirname "$RING_PATH")" /opt/1C/1CE/components/1c-enterprise-ring \
   && ln -sfn "$(dirname "$EDT_PATH")" /opt/1C/1CE/components/1cedt \
   && sed -i -e 's/4096m/12288m/g' "$(dirname "$EDT_PATH")"/1cedt.ini \
+  && sed -i '/^-Xmx/a --add-modules=javafx.controls,javafx.fxml,javafx.web\n--module-path=/usr/share/openjfx/lib' "$(dirname "$EDT_PATH")"/1cedt.ini \
   && "$(dirname "$EDT_PATH")"/1cedt -clean -purgeHistory -application org.eclipse.equinox.p2.director -noSplash -repository https://marmyshev.gitlab.io/edt-editing/update -installIU org.mard.dt.editing.feature.feature.group/${EDT_DISABLE_EDITING_VERSION} \
   && rm -f "$(dirname "$EDT_PATH")"/configuration/*.log \
   && rm -rf "$(dirname "$EDT_PATH")"/configuration/org.eclipse.core.runtime \

--- a/src/edt/2024.Dockerfile
+++ b/src/edt/2024.Dockerfile
@@ -28,6 +28,8 @@ RUN apt-get update \
     libgtk-3-0 \
     locales \
     ca-certificates \
+  && (DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y libwebkit2gtk-4.0-37 \
+      || DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y libwebkit2gtk-4.1-0) \
   && apt-get clean \
   && rm -rf  \
     /var/lib/apt/lists/* \

--- a/src/edt/2024.Dockerfile
+++ b/src/edt/2024.Dockerfile
@@ -61,7 +61,7 @@ RUN chmod +x ./1ce-installer-cli \
   && ln -sfn "$(dirname "$RING_PATH")" /opt/1C/1CE/components/1c-enterprise-ring \
   && ln -sfn "$(dirname "$EDT_PATH")" /opt/1C/1CE/components/1cedt \
   && sed -i -e 's/4096m/12288m/g' "$(dirname "$EDT_PATH")"/1cedt.ini \
-  && "$(dirname "$EDT_PATH")"/1cedt -clean -purgeHistory -application org.eclipse.equinox.p2.director -noSplash -repository https://marmyshev.gitlab.io/edt-editing/update -installIU org.mard.dt.editing.feature.feature.group/${EDT_DISABLE_EDITING_VERSION} \
+  && "$(dirname "$EDT_PATH")"/1cedt -clean -purgeHistory -application org.eclipse.equinox.p2.director -noSplash -repository https://marmyshev.gitlab.io/edt-editing/update -installIU org.mard.dt.editing.feature.feature.group/${EDT_DISABLE_EDITING_VERSION} -vmargs -Dorg.eclipse.swt.browser.DefaultType=webkit \
   && rm -f "$(dirname "$EDT_PATH")"/configuration/*.log \
   && rm -rf "$(dirname "$EDT_PATH")"/configuration/org.eclipse.core.runtime \
   && rm -rf "$(dirname "$EDT_PATH")"/configuration/org.eclipse.osgi \

--- a/src/edt/2024.Dockerfile
+++ b/src/edt/2024.Dockerfile
@@ -28,8 +28,6 @@ RUN apt-get update \
     libgtk-3-0 \
     locales \
     ca-certificates \
-  && (DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y libwebkit2gtk-4.0-37 \
-      || DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y libwebkit2gtk-4.1-0) \
   && apt-get clean \
   && rm -rf  \
     /var/lib/apt/lists/* \

--- a/src/edt/2024.Dockerfile
+++ b/src/edt/2024.Dockerfile
@@ -61,7 +61,7 @@ RUN chmod +x ./1ce-installer-cli \
   && ln -sfn "$(dirname "$RING_PATH")" /opt/1C/1CE/components/1c-enterprise-ring \
   && ln -sfn "$(dirname "$EDT_PATH")" /opt/1C/1CE/components/1cedt \
   && sed -i -e 's/4096m/12288m/g' "$(dirname "$EDT_PATH")"/1cedt.ini \
-  && "$(dirname "$EDT_PATH")"/1cedt -clean -purgeHistory -application org.eclipse.equinox.p2.director -noSplash -repository https://marmyshev.gitlab.io/edt-editing/update -installIU org.mard.dt.editing.feature.feature.group/${EDT_DISABLE_EDITING_VERSION} -vmargs -Dorg.eclipse.swt.browser.DefaultType=webkit \
+  && "$(dirname "$EDT_PATH")"/1cedt -clean -purgeHistory -application org.eclipse.equinox.p2.director -noSplash -repository https://marmyshev.gitlab.io/edt-editing/update -installIU org.mard.dt.editing.feature.feature.group/${EDT_DISABLE_EDITING_VERSION} \
   && rm -f "$(dirname "$EDT_PATH")"/configuration/*.log \
   && rm -rf "$(dirname "$EDT_PATH")"/configuration/org.eclipse.core.runtime \
   && rm -rf "$(dirname "$EDT_PATH")"/configuration/org.eclipse.osgi \

--- a/src/edt/2024.Dockerfile
+++ b/src/edt/2024.Dockerfile
@@ -49,26 +49,26 @@ COPY --from=downloader /tmp/${downloads} /tmp/${downloads}
 
 WORKDIR /tmp/${downloads}
 
-RUN chmod +x ./1ce-installer-cli \
-  && ./1ce-installer-cli install all --ignore-hardware-checks --ignore-signature-warnings && \
-  RING_PATH=$(find /opt/1C/1CE -type f -name ring -print -quit) && \
-  EDT_PATH=$(find /opt/1C/1CE -type f -name 1cedt -print -quit) && \
-  [ -n "$RING_PATH" ] && ln -s "$(dirname "$RING_PATH")" /opt/1C/1CE/components/1c-enterprise-ring && \
-  [ -n "$EDT_PATH" ] && ln -s "$(dirname "$EDT_PATH")" /opt/1C/1CE/components/1cedt && \
-  rm -rf /tmp/*
-
-# Install Disable Editing Plugin and cleanup
 ARG EDT_DISABLE_EDITING_VERSION=0.6.0.20250410-2002
-RUN /opt/1C/1CE/components/1cedt/1cedt -clean -purgeHistory -application org.eclipse.equinox.p2.director -noSplash -repository https://marmyshev.gitlab.io/edt-editing/update -installIU org.mard.dt.editing.feature.feature.group/${EDT_DISABLE_EDITING_VERSION} \
-  && rm -f /opt/1C/1CE/components/1cedt/configuration/*.log \
-  && rm -rf /opt/1C/1CE/components/1cedt/configuration/org.eclipse.core.runtime \
-  && rm -rf /opt/1C/1CE/components/1cedt/configuration/org.eclipse.osgi \
-  && rm -rf /opt/1C/1CE/components/1cedt/plugin-development \
-  && rm -f /opt/1C/1CE/components/1cedt/plugins/com._1c.g5.v8.dt.platform.doc_*.jar \
-  && rm -f /opt/1C/1CE/components/1cedt/plugins/com._1c.g5.v8.dt.platform.doc_v8_*.jar \
-  && rm -f /opt/1C/1CE/components/1cedt/plugins/com._1c.g5.v8.dt.product.doc_*.jar \
-  && rm -f /opt/1C/1CE/components/1cedt/plugins/org.eclipse.egit.doc_*.jar \
-  && rm -f /opt/1C/1CE/components/1cedt/plugins/org.eclipse.platform.doc_*.jar \
+RUN chmod +x ./1ce-installer-cli \
+  && ./1ce-installer-cli install all --ignore-hardware-checks --ignore-signature-warnings \
+  && RING_PATH="$(find /opt/1C/1CE -type f -name ring -print -quit)" \
+  && EDT_PATH="$(find /opt/1C/1CE -type f -name 1cedt -print -quit)" \
+  && [ -n "$RING_PATH" ] \
+  && [ -n "$EDT_PATH" ] \
+  && ln -sfn "$(dirname "$RING_PATH")" /opt/1C/1CE/components/1c-enterprise-ring \
+  && ln -sfn "$(dirname "$EDT_PATH")" /opt/1C/1CE/components/1cedt \
+  && sed -i -e 's/4096m/12288m/g' "$(dirname "$EDT_PATH")"/1cedt.ini \
+  && "$(dirname "$EDT_PATH")"/1cedt -clean -purgeHistory -application org.eclipse.equinox.p2.director -noSplash -repository https://marmyshev.gitlab.io/edt-editing/update -installIU org.mard.dt.editing.feature.feature.group/${EDT_DISABLE_EDITING_VERSION} \
+  && rm -f "$(dirname "$EDT_PATH")"/configuration/*.log \
+  && rm -rf "$(dirname "$EDT_PATH")"/configuration/org.eclipse.core.runtime \
+  && rm -rf "$(dirname "$EDT_PATH")"/configuration/org.eclipse.osgi \
+  && rm -rf "$(dirname "$EDT_PATH")"/plugin-development \
+  && rm -f "$(dirname "$EDT_PATH")"/plugins/com._1c.g5.v8.dt.platform.doc_*.jar \
+  && rm -f "$(dirname "$EDT_PATH")"/plugins/com._1c.g5.v8.dt.platform.doc_v8_*.jar \
+  && rm -f "$(dirname "$EDT_PATH")"/plugins/com._1c.g5.v8.dt.product.doc_*.jar \
+  && rm -f "$(dirname "$EDT_PATH")"/plugins/org.eclipse.egit.doc_*.jar \
+  && rm -f "$(dirname "$EDT_PATH")"/plugins/org.eclipse.platform.doc_*.jar \
   && rm -rf /tmp/*
 
 FROM base


### PR DESCRIPTION

- Кавычки в присваиваниях RING_PATH/EDT_PATH
- Явная проверка наличия обоих путей перед продолжением
- Идемпотентные симлинки через ln -sfn
- Не полагаемся на симлинк при sed/запуске/очистке — используем фактический каталог EDT через dirname(EDT_PATH)
- Синхронизировано для Dockerfile 2023 и 2024

Устраняет хрупкие падения при отсутствии файлов/существующих ссылок и повышает воспроизводимость сборок образов EDT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Улучшения**
  * Оптимизирован процесс установки и очистки среды, объединённый в одну команду для повышения эффективности.
  * Улучшена обработка путей и создание символических ссылок с использованием принудительной замены.
  * Увеличен объём выделяемой памяти для приложения с 4096м до 12288м.
  * Интегрирована установка плагина Disable Editing с дополнительными параметрами запуска.
  * Добавлена поддержка JavaFX через обновление конфигурации и установку необходимых пакетов.
  * Очистка временных файлов, логов и ненужных директорий теперь выполняется более корректно и последовательно.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->