### PR TITLE
fix: поддержка Docker Hub в скриптах сборки

### DIFF
--- a/scripts/docker_login.sh
+++ b/scripts/docker_login.sh
@@ -7,11 +7,19 @@ if [[ -z "$DOCKER_REGISTRY_URL" || -z "$DOCKER_LOGIN" || -z "$DOCKER_PASSWORD" ]
 fi
 
 set +x
-echo "$DOCKER_PASSWORD" | docker login "$DOCKER_REGISTRY_URL" -u "$DOCKER_LOGIN" --password-stdin
+
+login_url="$DOCKER_REGISTRY_URL"
+if [[ "$DOCKER_REGISTRY_URL" == docker.io/* ]]; then
+    login_url="docker.io"
+elif [[ "$DOCKER_REGISTRY_URL" != *.* ]] && [[ "$DOCKER_REGISTRY_URL" != */* ]]; then
+    login_url="docker.io"
+fi
+
+echo "$DOCKER_PASSWORD" | docker login "$login_url" -u "$DOCKER_LOGIN" --password-stdin
 
 if [[ $? -eq 0 ]]; then
-    echo "Успешная авторизация в $DOCKER_REGISTRY_URL"
+    echo "Успешная авторизация в $login_url"
 else
-    echo "Ошибка авторизации в $DOCKER_REGISTRY_URL"
+    echo "Ошибка авторизации в $login_url"
     exit 1
 fi

--- a/src/build-vrunner.sh
+++ b/src/build-vrunner.sh
@@ -62,12 +62,24 @@ if ! $found_local; then
         else
             echo "Не удалось получить базовый образ из реестра: $BASE_IMAGE_TAG" >&2
             echo "Выполняю локальную сборку базового образа onec-platform:${onec_version}" >&2
-            PUSH_IMAGE=${PUSH_IMAGE} ONEC_VERSION="$onec_version" CI_SUFFIX="${CI_SUFFIX:-}" DOCKER_REGISTRY_URL="${DOCKER_REGISTRY_URL:-}" "${SCRIPT_DIR}/build-onec-platform.sh"
+            PUSH_IMAGE=${PUSH_IMAGE} ONEC_VERSION="$onec_version" CI_SUFFIX="${CI_SUFFIX:-}" \
+                DOCKER_REGISTRY_URL="${DOCKER_REGISTRY_URL:-}" \
+                DOCKER_LOGIN="${DOCKER_LOGIN:-}" \
+                DOCKER_PASSWORD="${DOCKER_PASSWORD:-}" \
+                ONEC_USERNAME="${ONEC_USERNAME:-}" \
+                ONEC_PASSWORD="${ONEC_PASSWORD:-}" \
+                "${SCRIPT_DIR}/build-onec-platform.sh"
         fi
     else
         echo "DOCKER_REGISTRY_URL пустой или равен 'local' — пропускаю попытку pull и строю локально" >&2
         echo "Выполняю локальную сборку базового образа onec-platform:${onec_version}" >&2
-        PUSH_IMAGE=${PUSH_IMAGE} ONEC_VERSION="$onec_version" CI_SUFFIX="${CI_SUFFIX:-}" DOCKER_REGISTRY_URL="${DOCKER_REGISTRY_URL:-}" "${SCRIPT_DIR}/build-onec-platform.sh"
+        PUSH_IMAGE=${PUSH_IMAGE} ONEC_VERSION="$onec_version" CI_SUFFIX="${CI_SUFFIX:-}" \
+            DOCKER_REGISTRY_URL="${DOCKER_REGISTRY_URL:-}" \
+            DOCKER_LOGIN="${DOCKER_LOGIN:-}" \
+            DOCKER_PASSWORD="${DOCKER_PASSWORD:-}" \
+            ONEC_USERNAME="${ONEC_USERNAME:-}" \
+            ONEC_PASSWORD="${ONEC_PASSWORD:-}" \
+            "${SCRIPT_DIR}/build-onec-platform.sh"
     fi
 fi
 


### PR DESCRIPTION
# Изменения

- `scripts/docker_login.sh` — авторизация в docker.io для Docker Hub (даже если DOCKER_REGISTRY_URL содержит имя пользователя)
- `src/build-vrunner.sh` — исправлена передача переменных окружения (DOCKER_LOGIN, DOCKER_PASSWORD, ONEC_USERNAME, ONEC_PASSWORD) в `build-onec-platform.sh`

# Настройка для Docker Hub

Секреты в GitHub Actions:

- `DOCKER_REGISTRY_URL`: johnnyshut (или docker.io/johnnyshut)
- `DOCKER_LOGIN`: johnnyshut
- `DOCKER_PASSWORD`: <токен_с_правами_Read_Write_Delete>

# Результат

Образы публикуются в Docker Hub с корректными тегами: `johnnyshut/onec-platform:version` и `johnnyshut/vrunner:version`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Bug Fixes**
  * Улучшено нормализация адреса реестра при аутентификации в Docker для корректной работы с различными форматами URL реестра.

* **Refactor**
  * Оптимизирован процесс передачи учетных данных при локальной сборке образов, обеспечивая полный набор необходимых переменных окружения для аутентифицированного доступа к реестрам и сервисам.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->