### PR TITLE
Добавлен образ edt-vrunner

### DIFF
--- a/.github/workflows/build-edt-vrunner.yml
+++ b/.github/workflows/build-edt-vrunner.yml
@@ -1,0 +1,29 @@
+name: Build EDT vrunner Docker Image
+
+on:
+  push:
+    tags:
+      - 'edt-vrunner_*'   # реагировать на теги вида edt-vrunner_2025.2.3
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_REGISTRY_URL: ${{ secrets.DOCKER_REGISTRY_URL }}
+      DOCKER_LOGIN: ${{ secrets.DOCKER_LOGIN }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      ONEC_USERNAME: ${{ secrets.ONEC_USERNAME }}
+      ONEC_PASSWORD: ${{ secrets.ONEC_PASSWORD }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build, test and push edt-vrunner image
+        run: |
+          export EDT_VERSION="${GITHUB_REF#refs/tags/edt-vrunner_}"
+          echo "Собираем edt-vrunner версии ${EDT_VERSION}"
+          ./src/build-edt-vrunner.sh

--- a/.github/workflows/ci-edt-codepilot1c.yml
+++ b/.github/workflows/ci-edt-codepilot1c.yml
@@ -28,7 +28,7 @@ jobs:
     env:
       ONEC_USERNAME: ${{ secrets.ONEC_USERNAME }}
       ONEC_PASSWORD: ${{ secrets.ONEC_PASSWORD }}
-      DOCKER_REGISTRY_URL: ${{ secrets.DOCKER_REGISTRY_URL }}
+      DOCKER_REGISTRY_URL: 'local'
       DOCKER_LOGIN: ${{ secrets.DOCKER_LOGIN }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       PUSH_IMAGE: 'false'

--- a/.github/workflows/ci-edt-mcp-server.yml
+++ b/.github/workflows/ci-edt-mcp-server.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       ONEC_USERNAME: ${{ secrets.ONEC_USERNAME }}
       ONEC_PASSWORD: ${{ secrets.ONEC_PASSWORD }}
-      DOCKER_REGISTRY_URL: ${{ secrets.DOCKER_REGISTRY_URL }}
+      DOCKER_REGISTRY_URL: 'local'
       DOCKER_LOGIN: ${{ secrets.DOCKER_LOGIN }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       PUSH_IMAGE: 'false'

--- a/.github/workflows/ci-edt-vrunner.yml
+++ b/.github/workflows/ci-edt-vrunner.yml
@@ -10,6 +10,7 @@ on:
       - 'src/build-edt-vrunner.sh'
       - 'tests/test-edt-vrunner.sh'
       - 'scripts/**'
+      - 'tools/assert.sh'
       - '.github/workflows/ci-edt-vrunner.yml'
 
 jobs:

--- a/.github/workflows/ci-edt-vrunner.yml
+++ b/.github/workflows/ci-edt-vrunner.yml
@@ -1,0 +1,43 @@
+name: CI EDT vrunner (build-only on PR)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'src/edt/**'
+      - 'src/build-edt.sh'
+      - 'src/edt-vrunner/**'
+      - 'src/build-edt-vrunner.sh'
+      - 'tests/test-edt-vrunner.sh'
+      - 'scripts/**'
+      - '.github/workflows/ci-edt-vrunner.yml'
+
+jobs:
+  build-edt-vrunner:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        edt_version: [ '2026.1.2', '2025.2.6', '2025.1.5', '2024.2.6' ]
+
+    env:
+      ONEC_USERNAME: ${{ secrets.ONEC_USERNAME }}
+      ONEC_PASSWORD: ${{ secrets.ONEC_PASSWORD }}
+      DOCKER_REGISTRY_URL: ${{ secrets.DOCKER_REGISTRY_URL }}
+      DOCKER_LOGIN: ${{ secrets.DOCKER_LOGIN }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      PUSH_IMAGE: 'false'
+      FORCE_BUILD_BASE: 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build EDT vrunner ${{ matrix.edt_version }} (no push)
+        run: |
+          export EDT_VERSION="${{ matrix.edt_version }}"
+          ./src/build-edt-vrunner.sh

--- a/.github/workflows/ci-edt-vrunner.yml
+++ b/.github/workflows/ci-edt-vrunner.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       ONEC_USERNAME: ${{ secrets.ONEC_USERNAME }}
       ONEC_PASSWORD: ${{ secrets.ONEC_PASSWORD }}
-      DOCKER_REGISTRY_URL: ${{ secrets.DOCKER_REGISTRY_URL }}
+      DOCKER_REGISTRY_URL: 'local'
       DOCKER_LOGIN: ${{ secrets.DOCKER_LOGIN }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       PUSH_IMAGE: 'false'

--- a/.github/workflows/ci-edt.yml
+++ b/.github/workflows/ci-edt.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       ONEC_USERNAME: ${{ secrets.ONEC_USERNAME }}
       ONEC_PASSWORD: ${{ secrets.ONEC_PASSWORD }}
-      DOCKER_REGISTRY_URL: ${{ secrets.DOCKER_REGISTRY_URL }}
+      DOCKER_REGISTRY_URL: 'local'
       DOCKER_LOGIN: ${{ secrets.DOCKER_LOGIN }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       PUSH_IMAGE: 'false'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,7 +243,7 @@ PUSH_IMAGE=false ONEC_VERSION=8.3.27.1644 ./src/build-vrunner.sh
 | `ci-executor.yml` | изменения в executor | Матрица версий Исполнителя |
 | `ci-edt-mcp-server.yml` | изменения в edt-mcp-server | EDT 2025.2.3 + MCP 1.24.5 |
 | `ci-edt-codepilot1c.yml` | изменения в edt-codepilot1c | EDT 2025.2.3 + CodePilot 0.1.7.20260301-0607 |
-| `ci-edt-vrunner.yml` | изменения в edt-vrunner | Матрица EDT 2024.2.6, 2025.1.5, 2025.2.3, 2026.1.2 |
+| `ci-edt-vrunner.yml` | изменения в edt-vrunner | Матрица EDT 2024.2.6, 2025.1.5, 2025.2.6, 2026.1.2 |
 
 В PR-workflow используется `DOCKER_REGISTRY_URL=local` и `PUSH_IMAGE=false`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,12 @@ onec-images/
 - Headless-режим EDT, HTTP MCP-сервер на порту `8765`.
 - Bearer-токен генерируется автоматически при первом запуске или берётся из `EDT_CODEPILOT_BEARERTOKEN`.
 
+### `edt-vrunner`
+
+- vanessa-runner 3.x (канал `SNAPSHOT`) поверх базового образа `edt`.
+- Образ без серверной платформы 1С; команды `vrunner`, зависящие от `ibcmd` или информационной базы, недоступны.
+- Поддерживается EDT `>= 2024.2.6`.
+
 ### `executor`
 
 - Образ 1С:Исполнителя.
@@ -157,6 +163,9 @@ EDT_VERSION=2025.2.3 EDT_MCP_VERSION=1.24.5 ./src/build-edt-mcp-server.sh
 # EDT CodePilot1C
 EDT_VERSION=2025.2.3 EDT_CODEPILOT_VERSION=0.1.7.20260301-0607 ./src/build-edt-codepilot1c.sh
 
+# EDT vanessa-runner
+EDT_VERSION=2025.2.3 ./src/build-edt-vrunner.sh
+
 # Исполнитель
 EXECUTOR_VERSION=3.0.2.2 ./src/build-executor.sh
 
@@ -206,6 +215,7 @@ PUSH_IMAGE=false ONEC_VERSION=8.3.27.1644 ./src/build-vrunner.sh
 - `test-onec-platform.sh` — создаёт файловую информационную базу через `1cv8 CREATEINFOBASE`.
 - `test-edt.sh` — проверяет, что `1cedtcli` / `1cedtcli.sh` запускаются и версия совпадает.
 - `test-edt-mcp-server.sh` / `test-edt-codepilot1c.sh` — проверяют установку плагина, настройки `1cedt.ini` и доступность `/health`.
+- `test-edt-vrunner.sh` — проверяет запуск `vrunner`/`vrunner --help` и доступность `1cedtcli`.
 - `test-executor.sh` — проверяет вывод `--version`.
 - `test-vrunner.sh` / `test-vrunner2.sh` — проверяют help и создание базы через `init-dev --ibcmd`.
 
@@ -222,6 +232,7 @@ PUSH_IMAGE=false ONEC_VERSION=8.3.27.1644 ./src/build-vrunner.sh
 | `executor_<VERSION>` | `build-executor.yml` | `executor` |
 | `vrunner_<VERSION>` | `build-vrunner.yml` | `vrunner` |
 | `vrunner2_<VERSION>` | `build-vrunner2.yml` | `vrunner2` |
+| `edt-vrunner_<EDT_VERSION>` | `build-edt-vrunner.yml` | `edt-vrunner` |
 
 ### PR-проверки (build-only, без пуша)
 
@@ -232,6 +243,7 @@ PUSH_IMAGE=false ONEC_VERSION=8.3.27.1644 ./src/build-vrunner.sh
 | `ci-executor.yml` | изменения в executor | Матрица версий Исполнителя |
 | `ci-edt-mcp-server.yml` | изменения в edt-mcp-server | EDT 2025.2.3 + MCP 1.24.5 |
 | `ci-edt-codepilot1c.yml` | изменения в edt-codepilot1c | EDT 2025.2.3 + CodePilot 0.1.7.20260301-0607 |
+| `ci-edt-vrunner.yml` | изменения в edt-vrunner | Матрица EDT 2024.2.6, 2025.1.5, 2025.2.3, 2026.1.2 |
 
 В PR-workflow используется `DOCKER_REGISTRY_URL=local` и `PUSH_IMAGE=false`.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - [1С:EDT CLI (edtcli)](#1сedt-cli)
 - [1С:EDT MCP Server (edt-mcp-server)](#1сedt-mcp-server)
 - [1С:EDT CodePilot1C MCP (edt-codepilot1c)](#1cedt-codepilot1c-mcp)
+- [EDT vanessa-runner (edt-vrunner)](#edt-vanessa-runner-edt-vrunner)
 - [1С:Платформа (onec-platform)](#1сплатформа-onec-platform)
 - [vanessa-runner (vrunner)](#vanessa-runner-vrunner)
 
@@ -241,6 +242,53 @@
   - MCP-сервер по умолчанию принимает все мутации (`defaultMutationDecision=ALLOW`) и открывает весь инструментарий (`exposedTools=*`).
   - Параметры CodePilot прописаны статически в `1cedt.ini` во время сборки; runtime-переменные управляют только Bearer-токеном и `-Xmx`.
   - `FORCE_BUILD_BASE=true` — принудительно пересобрать базовый образ `edt` перед сборкой `edt-codepilot1c`.
+  - `NO_CACHE=true` — отключить кэш сборки.
+  - `DOCKER_SYSTEM_PRUNE=true` — предварительно очистить неиспользуемые слои/объекты Docker.
+
+[↑ Наверх](#onec-images)
+
+## EDT vanessa-runner (edt-vrunner)
+
+Образ на базе `edt` с предустановленным vanessa-runner 3.x (канал `SNAPSHOT`). Предназначен для CI/CD-сценариев, где уже используется EDT и требуется vanessa-runner. В отличие от образа `vrunner`, здесь отсутствует серверная платформа 1С, поэтому команды, зависящие от `ibcmd` или информационной базы, недоступны.
+
+- Требования:
+  - `DOCKER_REGISTRY_URL`, `DOCKER_LOGIN`, `DOCKER_PASSWORD` — доступ к приватному реестру, содержащему базовый образ `edt`.
+  - `EDT_VERSION` — версия EDT (совпадает с базовым образом), например `2025.2.3`.
+  - `ONEC_USERNAME`, `ONEC_PASSWORD` — для пересборки базового образа `edt`, если он отсутствует в реестре.
+
+- Триггер для сборки в Actions — тег вида `edt-vrunner_<EDT_VERSION>`, например `edt-vrunner_2025.2.3`.
+
+- Локальная сборка:
+  1. Убедитесь, что в реестре доступен образ `edt:$EDT_VERSION`. Если образ отсутствует — скрипт попытается сделать `docker pull`, а при неудаче выполнит локальную сборку через `build-edt.sh`.
+  2. Запустите сборку:
+     ```bash
+     EDT_VERSION=2025.2.3 ./src/build-edt-vrunner.sh
+     ```
+  - Без публикации в реестр:
+    ```bash
+    PUSH_IMAGE=false EDT_VERSION=2025.2.3 ./src/build-edt-vrunner.sh
+    ```
+  - Принудительная пересборка базового образа `edt` перед сборкой:
+    ```bash
+    FORCE_BUILD_BASE=true EDT_VERSION=2025.2.3 ./src/build-edt-vrunner.sh
+    ```
+
+- Результат локальной сборки — образ с тегом `$DOCKER_REGISTRY_URL/edt-vrunner:$EDT_VERSION`.
+
+- Примеры запуска:
+  ```bash
+  # Справка по vrunner
+  docker run --rm $DOCKER_REGISTRY_URL/edt-vrunner:2025.2.3 --help
+
+  # Проверка версии vanessa-runner
+  docker run --rm $DOCKER_REGISTRY_URL/edt-vrunner:2025.2.3 version
+
+  # Запуск произвольной команды vrunner
+  docker run --rm $DOCKER_REGISTRY_URL/edt-vrunner:2025.2.3 <команда>
+  ```
+
+- Полезно знать:
+  - `FORCE_BUILD_BASE=true` — принудительно пересобрать базовый образ `edt` перед сборкой `edt-vrunner`.
   - `NO_CACHE=true` — отключить кэш сборки.
   - `DOCKER_SYSTEM_PRUNE=true` — предварительно очистить неиспользуемые слои/объекты Docker.
 

--- a/src/build-edt-vrunner.sh
+++ b/src/build-edt-vrunner.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -z "${CI:-}" ]; then
+    echo "The script is not running in CI"
+    source "${SCRIPT_DIR}/../scripts/load_env.sh"
+else
+    echo "The script is running in CI"
+fi
+
+# Logging/assert helpers
+source "${SCRIPT_DIR}/../tools/assert.sh"
+
+# Defaults for CI-friendly behavior
+PUSH_IMAGE=${PUSH_IMAGE:-true}
+
+if [[ "${DOCKER_SYSTEM_PRUNE:-}" = "true" ]] ; then
+    docker system prune -af
+fi
+
+cache_arg=()
+if [[ "${NO_CACHE:-}" = "true" ]] ; then
+    cache_arg=(--no-cache)
+fi
+
+[[ -z "${EDT_VERSION:-}" ]] && { echo "Переменная EDT_VERSION не задана" >&2; exit 1; }
+edt_version=$EDT_VERSION
+
+if [[ -z "${DOCKER_REGISTRY_URL:-}" ]]; then
+    echo "Ошибка: для сборки edt-vrunner необходимо задать DOCKER_REGISTRY_URL (приватный реестр с образом edt)." >&2
+    exit 1
+fi
+
+# Form the image tag; allow local tag without registry for CI builds
+registry_prefix=""
+if [[ -n "${DOCKER_REGISTRY_URL:-}" ]]; then
+    registry_prefix="${DOCKER_REGISTRY_URL}/"
+fi
+IMAGE_TAG="${registry_prefix}edt-vrunner:${edt_version}${CI_SUFFIX:-}"
+BASE_IMAGE_TAG="${registry_prefix}edt:${edt_version}"
+
+if [[ "${FORCE_BUILD_BASE:-}" == "true" ]]; then
+    echo "Принудительная локальная сборка базового образа edt:${edt_version} (FORCE_BUILD_BASE=true)"
+    PUSH_IMAGE=${PUSH_IMAGE} EDT_VERSION="$edt_version" CI_SUFFIX="${CI_SUFFIX:-}" DOCKER_REGISTRY_URL="${DOCKER_REGISTRY_URL:-}" "${SCRIPT_DIR}/build-edt.sh"
+elif ! docker image inspect "$BASE_IMAGE_TAG" >/dev/null 2>&1; then
+    if [[ -n "${DOCKER_LOGIN:-}" && -n "${DOCKER_PASSWORD:-}" && -n "${DOCKER_REGISTRY_URL:-}" ]]; then
+        source "${SCRIPT_DIR}/../scripts/docker_login.sh"
+    fi
+
+    if docker pull "$BASE_IMAGE_TAG"; then
+        echo "Базовый образ получен из реестра: $BASE_IMAGE_TAG"
+    else
+        echo "Не удалось получить базовый образ из реестра: $BASE_IMAGE_TAG" >&2
+        echo "Выполняю локальную сборку базового образа edt:${edt_version}" >&2
+        PUSH_IMAGE=${PUSH_IMAGE} EDT_VERSION="$edt_version" CI_SUFFIX="${CI_SUFFIX:-}" DOCKER_REGISTRY_URL="${DOCKER_REGISTRY_URL:-}" "${SCRIPT_DIR}/build-edt.sh"
+    fi
+fi
+
+if [[ "$PUSH_IMAGE" == "true" ]]; then
+    source "${SCRIPT_DIR}/../scripts/docker_login.sh"
+fi
+
+DOCKER_BUILDKIT=1 docker build \
+    "${cache_arg[@]}" \
+    --build-arg EDT_VERSION="$EDT_VERSION" \
+    --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+    --build-arg DOCKER_REGISTRY_URL="${DOCKER_REGISTRY_URL}" \
+    -t "$IMAGE_TAG" \
+    -f "${SCRIPT_DIR}/edt-vrunner/Dockerfile" \
+    "${SCRIPT_DIR}/edt-vrunner"
+
+# Run tests against the built image
+if IMAGE_TAG="$IMAGE_TAG" ./tests/test-edt-vrunner.sh; then
+    if [[ "$PUSH_IMAGE" == "true" ]]; then
+        docker push "$IMAGE_TAG"
+    else
+        echo "Skipping push (PUSH_IMAGE=false)"
+    fi
+    source "${SCRIPT_DIR}/../scripts/cleanup.sh"
+else
+    log_failure "ERROR: Tests failed. Docker image will not be pushed."
+    source "${SCRIPT_DIR}/../scripts/cleanup.sh"
+    exit 1
+fi
+exit 0

--- a/src/edt-vrunner/Dockerfile
+++ b/src/edt-vrunner/Dockerfile
@@ -1,0 +1,63 @@
+ARG DOCKER_REGISTRY_URL
+ARG EDT_VERSION
+
+# Готовый OneScript из OVM
+FROM sleemp/oscript:stable AS oscript
+
+# Финальный образ — EDT из приватного реестра под нужную версию
+FROM ${DOCKER_REGISTRY_URL}/edt:${EDT_VERSION}
+
+# Метаданные
+ARG EDT_VERSION
+ARG BUILD_DATE
+LABEL maintainer="Iosif Pravets <i@pravets.ru>" \
+      org.opencontainers.image.title="edt-vrunner" \
+      org.opencontainers.image.description="vanessa-runner поверх edt ${EDT_VERSION}" \
+      org.opencontainers.image.created="${BUILD_DATE}"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+USER root
+
+ARG MONO_VERSION=6.12.0.182
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+       ca-certificates \
+       gnupg \
+       dirmngr \
+       wget \
+       locales \
+  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
+  && echo "deb http://download.mono-project.com/repo/debian stable-buster/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official-stable.list \
+  && apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+       mono-runtime \
+       ca-certificates-mono \
+       libmono-i18n4.0-all \
+       libmono-system-runtime-serialization4.0-cil \
+       libicu-dev \
+  && rm -rf /etc/apt/sources.list.d/mono-official-stable.list \
+  && apt-get update \
+  && cert-sync --user /etc/ssl/certs/ca-certificates.crt \
+  && rm -rf  \
+      /var/lib/apt/lists/* \
+      /var/cache/debconf \
+  && locale-gen ru_RU.UTF-8 \
+  && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
+
+ENV LANG=ru_RU.UTF-8 \
+    LC_ALL=ru_RU.UTF-8 \
+    LANGUAGE=ru_RU:ru
+
+WORKDIR /root
+
+COPY --from=oscript /root/.local/share/ovm/stable/ /root/.local/share/ovm/stable/
+
+ENV OSCRIPTBIN=/root/.local/share/ovm/current/bin
+ENV PATH="$OSCRIPTBIN:$PATH"
+
+RUN ln -s /root/.local/share/ovm/stable /root/.local/share/ovm/current \
+  && opm install vanessa-runner@SNAPSHOT add
+
+ENTRYPOINT ["vrunner"]
+CMD ["--help"]

--- a/src/edt-vrunner/Dockerfile
+++ b/src/edt-vrunner/Dockerfile
@@ -27,8 +27,8 @@ RUN apt-get update \
        dirmngr \
        wget \
        locales \
-  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-  && echo "deb http://download.mono-project.com/repo/debian stable-buster/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official-stable.list \
+  && gpg --homedir /tmp --batch --yes --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
+  && echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] http://download.mono-project.com/repo/debian stable-buster/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official-stable.list \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
        mono-runtime \

--- a/src/edt-vrunner/Dockerfile
+++ b/src/edt-vrunner/Dockerfile
@@ -24,11 +24,13 @@ RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
        ca-certificates \
        gnupg \
-       dirmngr \
        wget \
        locales \
-  && gpg --homedir /tmp --batch --yes --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-  && echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] http://download.mono-project.com/repo/debian stable-buster/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official-stable.list \
+  && wget -qO- https://download.mono-project.com/repo/xamarin.gpg \
+     | gpg --dearmor -o /usr/share/keyrings/mono-official-archive-keyring.gpg \
+  && chmod +r /usr/share/keyrings/mono-official-archive-keyring.gpg \
+  && echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu stable-focal/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official-stable.list \
+  && printf 'Package: mono* libmono* ca-certificates-mono\nPin: origin download.mono-project.com\nPin-Priority: 1001\n' > /etc/apt/preferences.d/mono \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
        mono-runtime \
@@ -36,7 +38,7 @@ RUN apt-get update \
        libmono-i18n4.0-all \
        libmono-system-runtime-serialization4.0-cil \
        libicu-dev \
-  && rm -rf /etc/apt/sources.list.d/mono-official-stable.list \
+  && rm -rf /etc/apt/sources.list.d/mono-official-stable.list /etc/apt/preferences.d/mono \
   && apt-get update \
   && cert-sync --user /etc/ssl/certs/ca-certificates.crt \
   && rm -rf  \

--- a/src/vrunner/Dockerfile
+++ b/src/vrunner/Dockerfile
@@ -23,11 +23,13 @@ RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
        ca-certificates \
        gnupg \
-       dirmngr \
        wget \
        locales \
-  && gpg --homedir /tmp --batch --yes --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-  && echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] http://download.mono-project.com/repo/debian stable-buster/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official-stable.list \
+  && wget -qO- https://download.mono-project.com/repo/xamarin.gpg \
+     | gpg --dearmor -o /usr/share/keyrings/mono-official-archive-keyring.gpg \
+  && chmod +r /usr/share/keyrings/mono-official-archive-keyring.gpg \
+  && echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu stable-focal/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official-stable.list \
+  && printf 'Package: mono* libmono* ca-certificates-mono\nPin: origin download.mono-project.com\nPin-Priority: 1001\n' > /etc/apt/preferences.d/mono \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
        mono-runtime \
@@ -35,12 +37,14 @@ RUN apt-get update \
        libmono-i18n4.0-all \
        libmono-system-runtime-serialization4.0-cil \
        libicu-dev \
-  && rm -rf /etc/apt/sources.list.d/mono-official-stable.list \
+  && rm -rf /etc/apt/sources.list.d/mono-official-stable.list /etc/apt/preferences.d/mono \
   && apt-get update \
   && cert-sync --user /etc/ssl/certs/ca-certificates.crt \
   && rm -rf  \
       /var/lib/apt/lists/* \
       /var/cache/debconf \
+  && mkdir -p /usr/share/locale \
+  && touch /usr/share/locale/locale.alias \
   && locale-gen ru_RU.UTF-8 \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
 

--- a/src/vrunner/Dockerfile
+++ b/src/vrunner/Dockerfile
@@ -26,8 +26,8 @@ RUN apt-get update \
        dirmngr \
        wget \
        locales \
-  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-  && echo "deb http://download.mono-project.com/repo/debian stable-buster/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official-stable.list \
+  && gpg --homedir /tmp --batch --yes --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
+  && echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] http://download.mono-project.com/repo/debian stable-buster/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official-stable.list \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
        mono-runtime \

--- a/src/vrunner2/Dockerfile
+++ b/src/vrunner2/Dockerfile
@@ -23,11 +23,13 @@ RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
        ca-certificates \
        gnupg \
-       dirmngr \
        wget \
        locales \
-  && gpg --homedir /tmp --batch --yes --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-  && echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] http://download.mono-project.com/repo/debian stable-buster/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official-stable.list \
+  && wget -qO- https://download.mono-project.com/repo/xamarin.gpg \
+     | gpg --dearmor -o /usr/share/keyrings/mono-official-archive-keyring.gpg \
+  && chmod +r /usr/share/keyrings/mono-official-archive-keyring.gpg \
+  && echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu stable-focal/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official-stable.list \
+  && printf 'Package: mono* libmono* ca-certificates-mono\nPin: origin download.mono-project.com\nPin-Priority: 1001\n' > /etc/apt/preferences.d/mono \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
        mono-runtime \
@@ -35,12 +37,14 @@ RUN apt-get update \
        libmono-i18n4.0-all \
        libmono-system-runtime-serialization4.0-cil \
        libicu-dev \
-  && rm -rf /etc/apt/sources.list.d/mono-official-stable.list \
+  && rm -rf /etc/apt/sources.list.d/mono-official-stable.list /etc/apt/preferences.d/mono \
   && apt-get update \
   && cert-sync --user /etc/ssl/certs/ca-certificates.crt \
   && rm -rf  \
       /var/lib/apt/lists/* \
       /var/cache/debconf \
+  && mkdir -p /usr/share/locale \
+  && touch /usr/share/locale/locale.alias \
   && locale-gen ru_RU.UTF-8 \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
 

--- a/src/vrunner2/Dockerfile
+++ b/src/vrunner2/Dockerfile
@@ -26,8 +26,8 @@ RUN apt-get update \
        dirmngr \
        wget \
        locales \
-  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-  && echo "deb http://download.mono-project.com/repo/debian stable-buster/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official-stable.list \
+  && gpg --homedir /tmp --batch --yes --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
+  && echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] http://download.mono-project.com/repo/debian stable-buster/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official-stable.list \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
        mono-runtime \

--- a/tests/test-edt-vrunner.sh
+++ b/tests/test-edt-vrunner.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ -z "${CI-}" ]; then
+  echo "The script is not running in CI"
+  # .env may not exist locally; ignore if missing
+  [ -f .env ] && source .env || true
+else
+  echo "The script is running in CI"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../tools/assert.sh"
+
+TEST_FAILED=0
+
+# Resolve image tag from env or defaults (matches build-edt-vrunner.sh scheme)
+resolve_image_tag() {
+  if [[ -n "${IMAGE_TAG:-}" ]]; then
+    echo "$IMAGE_TAG"
+    return
+  fi
+  local prefix=""
+  if [[ -n "${DOCKER_REGISTRY_URL:-}" ]]; then
+    prefix="${DOCKER_REGISTRY_URL}/"
+  fi
+  if [[ -z "${EDT_VERSION:-}" ]]; then
+    log_failure "EDT_VERSION не задан и IMAGE_TAG пуст — невозможно определить тег образа"
+    exit 1
+  fi
+  echo "${prefix}edt-vrunner:${EDT_VERSION}${CI_SUFFIX:-}"
+}
+
+test_run_without_params() {
+  log_header "Test :: vrunner run without params"
+
+  local tag
+  tag="$(resolve_image_tag)"
+
+  # Run container and capture first lines of output to avoid hanging
+  local out
+  out=$(docker run --rm "$tag" 2>&1 | sed -n '1,20p' || true)
+
+  # Basic checks — ensure binary identifies itself and prints commands list
+  if ! assert_contain "$out" "Приложение: vrunner" "Ожидается сообщение о приложении"; then TEST_FAILED=1; return 1; fi
+
+  log_success "vrunner run without params test passed"
+}
+
+test_help_shows_commands() {
+  log_header "Test :: vrunner --help shows commands"
+
+  local tag
+  tag="$(resolve_image_tag)"
+
+  local out
+  out=$(docker run --rm "$tag" --help 2>&1 | sed -n '1,50p' || true)
+
+  if ! assert_contain "$out" "Доступные команды:" "--help должен содержать раздел 'Доступные команды'"; then TEST_FAILED=1; return 1; fi
+  if ! assert_contain "$out" "help, h" "--help должен перечислять help"; then TEST_FAILED=1; return 1; fi
+  if ! assert_contain "$out" "cf" "--help должен перечислять cf"; then TEST_FAILED=1; return 1; fi
+
+  log_success "vrunner --help test passed"
+}
+
+test_1cedtcli_is_available() {
+  log_header "Test :: 1cedtcli is available in edt-vrunner image"
+
+  local tag
+  tag="$(resolve_image_tag)"
+
+  local out
+  out=$(docker run --rm --entrypoint 1cedtcli "$tag" --help 2>/dev/null | head -n1 || true)
+
+  if ! assert_contain "$out" "1C:EDT Интерфейс командной строки" "Ожидается заголовок 1cedtcli"; then TEST_FAILED=1; return 1; fi
+
+  log_success "1cedtcli availability test passed"
+}
+
+# Run tests
+test_run_without_params || true
+test_help_shows_commands || true
+test_1cedtcli_is_available || true
+
+[[ -n "${CI:-}" ]] && exit "$TEST_FAILED" || exit 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Добавлен Docker-образ **EDT vanessa-runner (edt-vrunner)** с поддержкой `vrunner` и `1cedtcli`.
  * Добавлены команды/скрипты для локальной сборки, валидации и сборки базового образа (с режимами без публикации и пересборки).
  * Настроены автоматические сборки в GitHub Actions: по тегам и проверки сборки на PR для поддерживаемых версий EDT.
* **Исправления**
  * Добавлены интеграционные проверки запуска `vrunner`, вывода справки и доступности `1cedtcli`.
* **Документация**
  * Обновлены README и AGENTS с описанием образа и сценариями сборки/тестирования.
* **Chores / Обновления сборки**
  * Уточнены настройки CI registry и улучшены шаги установки Mono/локали в образах `vrunner`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->