### PR TITLE
fix: релизные теги bsl-sonar-scanner-cli-v<N> не запускают сборку

### DIFF
--- a/.github/workflows/build-bsl-sonar-scanner-cli.yml
+++ b/.github/workflows/build-bsl-sonar-scanner-cli.yml
@@ -3,8 +3,8 @@ name: Build bsl-sonar-scanner-cli Docker Image
 on:
   push:
     tags:
-      - 'bsl-sonar-scanner-cli_*'   # версионированная сборка: bsl-sonar-scanner-cli_<SONAR>[-<ONEC>]
-      - 'bsl-sonar-scanner-cli-v*'  # релизная сборка: bsl-sonar-scanner-cli-v<N> (дефолтные версии)
+      - 'bsl-sonar-scanner-cli_*'   # сборка по версионированному тегу: bsl-sonar-scanner-cli_<SONAR>[-<ONEC>]
+      # Теги вида bsl-sonar-scanner-cli-v<N> — маркеры релиза, сборку НЕ запускают.
 
 jobs:
   build:
@@ -26,24 +26,16 @@ jobs:
 
       - name: Build, test and push bsl-sonar-scanner-cli image
         run: |
-          ref="${GITHUB_REF#refs/tags/}"
-          if [[ "$ref" == bsl-sonar-scanner-cli_* ]]; then
-            # Версионированная сборка: bsl-sonar-scanner-cli_<SONAR>[-<ONEC>]
-            # Разделитель '-' — в SONAR_SCANNER_VERSION может встречаться '_'
-            # (например 12.1.0.3233_8.0.1). ONEC_VERSION опционален:
-            # если не задан, build-скрипт использует прибитую молотком версию.
-            version_part="${ref#bsl-sonar-scanner-cli_}"
-            if [[ "$version_part" == *-* ]]; then
-              export SONAR_SCANNER_VERSION="${version_part%%-*}"
-              export ONEC_VERSION="${version_part#*-}"
-            else
-              export SONAR_SCANNER_VERSION="$version_part"
-            fi
-            echo "Версионированная сборка: сканер ${SONAR_SCANNER_VERSION}, onec-platform ${ONEC_VERSION:-<молоток>}"
+          version_part="${GITHUB_REF#refs/tags/bsl-sonar-scanner-cli_}"
+          # Формат тега: bsl-sonar-scanner-cli_<SONAR_SCANNER_VERSION>[-<ONEC_VERSION>]
+          # Разделитель '-' — в SONAR_SCANNER_VERSION может встречаться '_'
+          # (например 12.1.0.3233_8.0.1). ONEC_VERSION опционален:
+          # если не задан, build-скрипт использует прибитую молотком версию.
+          if [[ "$version_part" == *-* ]]; then
+            export SONAR_SCANNER_VERSION="${version_part%%-*}"
+            export ONEC_VERSION="${version_part#*-}"
           else
-            # Релизная сборка: bsl-sonar-scanner-cli-v<N> → docker-тег v<N>,
-            # версии — дефолтные (молоток onec-platform + закреплённый сканер)
-            export RELEASE_TAG="${ref#bsl-sonar-scanner-cli-}"
-            echo "Релизная сборка: docker-тег ${RELEASE_TAG}, дефолтные версии"
+            export SONAR_SCANNER_VERSION="$version_part"
           fi
+          echo "Собираем bsl-sonar-scanner-cli: сканер ${SONAR_SCANNER_VERSION}, onec-platform ${ONEC_VERSION:-<молоток>}"
           ./src/build-bsl-sonar-scanner-cli.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,8 +253,7 @@ PUSH_IMAGE=false ONEC_VERSION=8.3.27.1644 ./src/build-vrunner.sh
 | `vrunner_<VERSION>` | `build-vrunner.yml` | `vrunner` |
 | `vrunner2_<VERSION>` | `build-vrunner2.yml` | `vrunner2` |
 | `edt-vrunner_<EDT_VERSION>` | `build-edt-vrunner.yml` | `edt-vrunner` |
-| `bsl-sonar-scanner-cli_<SONAR>[-<ONEC>]` | `build-bsl-sonar-scanner-cli.yml` | `bsl-sonar-scanner-cli` (ONEC опционален, разделитель `-`) |
-| `bsl-sonar-scanner-cli-v<N>` | `build-bsl-sonar-scanner-cli.yml` | `bsl-sonar-scanner-cli:v<N>` (релиз, дефолтные версии) |
+| `bsl-sonar-scanner-cli_<SONAR>[-<ONEC>]` | `build-bsl-sonar-scanner-cli.yml` | `bsl-sonar-scanner-cli` (ONEC опционален, разделитель `-`). Теги `bsl-sonar-scanner-cli-v<N>` — маркеры релиза, сборку не запускают |
 
 ### PR-проверки (build-only, без пуша)
 

--- a/README.md
+++ b/README.md
@@ -378,9 +378,7 @@ PUSH_IMAGE=false ./src/build-bsl-sonar-scanner-cli.sh
 PUSH_IMAGE=false ONEC_VERSION=8.3.27.1859 SONAR_SCANNER_VERSION=12.1.0.3233_8.0.1 ./src/build-bsl-sonar-scanner-cli.sh
 ```
 
-Сборка через GitHub Actions по тегу. Два семейства тегов (различаются первым символом после имени — `_` или `-`):
-
-**Версионированная сборка** — `bsl-sonar-scanner-cli_<SONAR_SCANNER_VERSION>[-<ONEC_VERSION>]`, где `ONEC_VERSION` опционален (если не задан — берётся прибитая молотком версия). Разделитель `-`, т.к. в версии сканера встречается `_` (JRE-суффикс):
+Сборка через GitHub Actions по тегу. Формат тега: `bsl-sonar-scanner-cli_<SONAR_SCANNER_VERSION>[-<ONEC_VERSION>]`, где `ONEC_VERSION` опционален (если не задан — берётся прибитая молотком версия). Разделитель `-`, т.к. в версии сканера встречается `_` (JRE-суффикс):
 
 ```bash
 # сканер 12.1.0.3233_8.0.1, onec-platform = молоток (8.3.27.2214)
@@ -390,8 +388,8 @@ git tag bsl-sonar-scanner-cli_12.1.0.3233_8.0.1
 git tag bsl-sonar-scanner-cli_12.1.0.3233_8.0.1-8.3.27.1859
 ```
 
-**Релизная сборка** — `bsl-sonar-scanner-cli-v<N>` (например `bsl-sonar-scanner-cli-v1`): собирается с дефолтными версиями (молоток onec-platform + закреплённый сканер) и публикуется под docker-тегом `v<N>`.
+Тег Docker-образа повторяет git-тег: `bsl-sonar-scanner-cli:12.1.0.3233_8.0.1[-8.3.27.1859]`.
 
-Тег Docker-образа повторяет git-тег: `bsl-sonar-scanner-cli:12.1.0.3233_8.0.1[-8.3.27.1859]` или `bsl-sonar-scanner-cli:v1` для релиза.
+Теги вида `bsl-sonar-scanner-cli-v<N>` — маркеры релиза, сборку **не** запускают.
 
 [↑ Наверх](#onec-images)

--- a/src/build-bsl-sonar-scanner-cli.sh
+++ b/src/build-bsl-sonar-scanner-cli.sh
@@ -52,12 +52,6 @@ if [[ "$ONEC_VERSION_EXPLICIT" == "true" ]]; then
 fi
 IMAGE_TAG="${registry_prefix}bsl-sonar-scanner-cli:${SONAR_SCANNER_VERSION}${ONEC_TAG_SUFFIX}${CI_SUFFIX:-}"
 
-# Релизный тег (workflow по тегу bsl-sonar-scanner-cli-v<N>):
-# bsl-sonar-scanner-cli:v<N> с дефолтными версиями, переопределяет IMAGE_TAG
-if [[ -n "${RELEASE_TAG:-}" ]]; then
-    IMAGE_TAG="${registry_prefix}bsl-sonar-scanner-cli:${RELEASE_TAG}${CI_SUFFIX:-}"
-fi
-
 # Резолвим базовый образ onec-platform (источник hbk-файлов).
 # Предпочитаем локальный образ без префикса (onec-platform:${ONEC_VERSION}),
 # затем с префиксом реестра; иначе pull из реестра; в крайнем случае —


### PR DESCRIPTION
Тег `bsl-sonar-scanner-cli-v1` нужен только как маркер релиза — образ под ним собираться не должен.

- Убран триггер `bsl-sonar-scanner-cli-v*` из `build-bsl-sonar-scanner-cli.yml`
- Удалена поддержка `RELEASE_TAG` из build-скрипта
- Документация обновлена: `-v<N>` — маркеры, сборку не запускают

Версионированные теги `bsl-sonar-scanner-cli_<SONAR>[-<ONEC>]` работают как раньше.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения**
  * Сборки теперь запускаются только для тегов формата `bsl-sonar-sonar-scanner-cli_*`.
  * Релизные теги `bsl-sonar-scanner-cli-v<N>` используются только как маркеры релиза и не запускают сборку.
  * Имена создаваемых образов теперь всегда формируются на основе версий сканера, платформы и CI-суффикса.

* **Документация**
  * Уточнены правила именования тегов и запуска сборок.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->